### PR TITLE
limit to run on specific list of chart patterns by default

### DIFF
--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -35,7 +35,7 @@ void ml_init(void) {
     std::string HostsToSkip = config_get(CONFIG_SECTION_ML, "hosts to skip from training", "!*");
     Cfg.SP_HostsToSkip = simple_pattern_create(HostsToSkip.c_str(), NULL, SIMPLE_PATTERN_EXACT);
 
-    std::string ChartsToSkip = config_get(CONFIG_SECTION_ML, "charts to skip from training", "!*");
+    std::string ChartsToSkip = config_get(CONFIG_SECTION_ML, "charts to skip from training", "!system.* !cpu.* !mem.* !disk.* !disk_* !ip.* !ipv4.* !ipv6.* !net.* !net_* !netfilter.* !services.* !apps.* !groups.* !users.* !ebpf.* !netdata.* *");
     Cfg.SP_ChartsToSkip = simple_pattern_create(ChartsToSkip.c_str(), NULL, SIMPLE_PATTERN_EXACT);
 
     Cfg.Initialized = true;


### PR DESCRIPTION
limit to run on specific list of chart patterns by default. if your netdata has more charts you want to run it on then safer to have a default list so as to have known/typical performance out of the box.